### PR TITLE
Ocultar errores tipo warning.

### DIFF
--- a/main-app/compartido/head.php
+++ b/main-app/compartido/head.php
@@ -16,9 +16,11 @@ if(isset($idPaginaInterna)){
 	");
 	$publicidadPopUp = mysqli_fetch_array($publicidadPopUpConsulta, MYSQLI_BOTH);
 
-	$numMostrarPopUpConsulta = mysqli_query($conexion, "SELECT * FROM ".$baseDatosServicios.".publicidad_estadisticas 
-	WHERE pest_publicidad='".$publicidadPopUp['pub_id']."' AND pest_institucion='".$config['conf_id_institucion']."' AND pest_usuario='".$_SESSION["id"]."' AND pest_ubicacion=3");
-	$numMostrarPopUp = mysqli_num_rows($numMostrarPopUpConsulta);
+	if(isset($publicidadPopUp['pub_id'])){
+		$numMostrarPopUpConsulta = mysqli_query($conexion, "SELECT * FROM ".$baseDatosServicios.".publicidad_estadisticas 
+		WHERE pest_publicidad='".$publicidadPopUp['pub_id']."' AND pest_institucion='".$config['conf_id_institucion']."' AND pest_usuario='".$_SESSION["id"]."' AND pest_ubicacion=3");
+		$numMostrarPopUp = mysqli_num_rows($numMostrarPopUpConsulta);
+	}
 }
 
 ?>

--- a/main-app/modelo/conexion.php
+++ b/main-app/modelo/conexion.php
@@ -1,5 +1,5 @@
 <?php 
-error_reporting (E_ALL ^ E_NOTICE);
+error_reporting (E_ALL ^ E_NOTICE ^ E_WARNING);
 
 if (strpos($_SERVER['PHP_SELF'], 'salir.php')) {
     session_start();


### PR DESCRIPTION
Estos son errores de advertencia, pero por ahora se puede trabajar así. En php 8.1 estas advertencias se muestran para avisarnos de cosas que debemos mejorar, pero no son un problema importante para corregir.