### PR TITLE
Mejoras en el submodulo de admisiones e inscripciones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ main-app/modelo/error_log
 main-app/controlador/error_log
 main-app/admisiones/error_log
 main-app/files
+main-app/admisiones/bd-conexion.php
+main-app/admisiones/files

--- a/config-general/config-admisiones.php
+++ b/config-general/config-admisiones.php
@@ -1,4 +1,18 @@
 <?php
+switch($_SERVER['HTTP_HOST']){
+	case 'localhost':
+	$BD_ADMISIONES_MOCK = 'odermangroup_dev_2023';
+	break;
+
+	case 'developer.plataformasintia.com':
+    $BD_ADMISIONES_MOCK = 'mobiliar_dev_2023';
+	break;
+
+	case 'main.plataformasintia.com':
+    $BD_ADMISIONES_MOCK = 'mobiliar_dev_2023';
+	break;
+}
+
 #VARIABLES PARA SUBMODULO DE ADMISIONES
 $estadosSolicitud = array(
 	1 => 'VERIFICACIÓN DE PAGO', 

--- a/config-general/config-admisiones.php
+++ b/config-general/config-admisiones.php
@@ -1,0 +1,24 @@
+<?php
+#VARIABLES PARA SUBMODULO DE ADMISIONES
+$estadosSolicitud = array(
+	1 => 'VERIFICACIÓN DE PAGO', 
+	2 => 'PAGO RECHAZADO', 
+	3 => 'PENDIENTE POR DILIGENCIAR EL FORMULARIO',
+	4 => 'EN PROCESO',
+	5 => 'EXAMEN Y ENTREVISTA', 
+	6 => 'APROBADO', 
+	7 => 'NO APROBADO',
+	8 => 'VERIFICACIÓN DE CUPO DISPONIBLE',
+	9 => 'MOVIDO AL AÑO SIGUIENTE'
+);
+$progresoSolicitud = array(
+	1 => '15%', 
+	2 => '15%', 
+	3 => '30%', 
+	4 => '60%',
+	5 => '75%', 
+	6 => '90%',
+	7 => '100%',
+	8 => '15%',
+	9 => '100%',
+);

--- a/main-app/admisiones/bd-conexion.php
+++ b/main-app/admisiones/bd-conexion.php
@@ -1,11 +1,13 @@
 <?php
 require_once($_SERVER['DOCUMENT_ROOT']."/app-sintia/config-general/constantes.php");
 require_once(ROOT_PATH."/conexion-datos.php");
-$server = $servidorConexion;
-$user = $usuarioConexion;
-$pass = $claveConexion;
-$dbName = $baseDatosAdmisiones;
-$dbNameInstitucion = 'odermangroup_dev_2024';
+require_once($_SERVER['DOCUMENT_ROOT']."/app-sintia/config-general/config-admisiones.php");
+
+$server 		   = $servidorConexion;
+$user   		   = $usuarioConexion;
+$pass   		   = $claveConexion;
+$dbName 		   = $baseDatosAdmisiones;
+$dbNameInstitucion = $BD_ADMISIONES_MOCK;
 
 try{
 	$pdo = new PDO('mysql:host='.$server.';dbname='.$dbName, $user, $pass);
@@ -22,5 +24,3 @@ try{
 	echo "Error!: " . $e->getMessage() . "<br/>";
 	die();
 }
-
-require_once($_SERVER['DOCUMENT_ROOT']."/app-sintia/config-general/config-admisiones.php");

--- a/main-app/admisiones/bd-conexion.php
+++ b/main-app/admisiones/bd-conexion.php
@@ -1,10 +1,11 @@
 <?php
-include("../directivo/session.php");
+require_once($_SERVER['DOCUMENT_ROOT']."/app-sintia/config-general/constantes.php");
+require_once(ROOT_PATH."/conexion-datos.php");
 $server = $servidorConexion;
 $user = $usuarioConexion;
 $pass = $claveConexion;
 $dbName = $baseDatosAdmisiones;
-$dbNameInstitucion = $bdActual;
+$dbNameInstitucion = 'odermangroup_dev_2024';
 
 try{
 	$pdo = new PDO('mysql:host='.$server.';dbname='.$dbName, $user, $pass);
@@ -22,26 +23,4 @@ try{
 	die();
 }
 
-#CONSTANTES
-$estadosSolicitud = array(
-	1 => 'VERIFICACIÓN DE PAGO', 
-	2 => 'PAGO RECHAZADO', 
-	3 => 'PENDIENTE POR DILIGENCIAR EL FORMULARIO',
-	4 => 'EN PROCESO',
-	5 => 'EXAMEN Y ENTREVISTA', 
-	6 => 'APROBADO', 
-	7 => 'NO APROBADO',
-	8 => 'VERIFICACIÓN DE CUPO DISPONIBLE',
-	9 => 'MOVIDO AL AÑO SIGUIENTE'
-);
-$progresoSolicitud = array(
-	1 => '15%', 
-	2 => '15%', 
-	3 => '30%', 
-	4 => '60%',
-	5 => '75%', 
-	6 => '90%',
-	7 => '100%',
-	8 => '15%',
-	9 => '100%',
-);
+require_once($_SERVER['DOCUMENT_ROOT']."/app-sintia/config-general/config-admisiones.php");


### PR DESCRIPTION
Se corrigió lo siguiente:
- Que NO se solicitara la sesión del directivo para poder hacer un registro en admisiones.
- Que la BD cargara, por ahora, mockeada según el ambiente. Esto es algo que se debe corregir más adelante para que cargue según la institución aspirante.
- Que por seguridad se ignorara el archivo de conexión a la BD, aunque no tuviera los datos explicitamente.