### PR TITLE
HTF - Se corrige error al agregar un curso de MT a un estudiante

### DIFF
--- a/main-app/directivo/includes/info-academica.php
+++ b/main-app/directivo/includes/info-academica.php
@@ -312,7 +312,7 @@
 						select1.add(opcion);
 					}
 					select1.addEventListener('change', function() {
-						editarEstudainte(valor);
+						editarCurso(valor);
 					});
 					// creamos el select del estado
 					var select2 = document.createElement("select");
@@ -327,7 +327,7 @@
 					}
 					select2.value='<?php echo ESTADO_CURSO_PRE_INSCRITO ?>';
 					select2.addEventListener('change', function() {
-						editarEstudainte(valor);
+						editarCurso(valor);
 					});
 
 					// Crea un elemento de botón


### PR DESCRIPTION
Docente de icolven reporta que al momento de agregarle un curso de MT a un estudiante no le permite cambiarle el grupo o el estado a menos de que le de en finalizar y se vuelva a recargar la pagina, se hace validación y se ve que al agregar el curso esta se detecta que los select generados por JS del estado y grupo estan llamando a una función no existente