### PR TITLE
HTF - Se corrige error para fechas de actividades en los estudiantes

### DIFF
--- a/main-app/class/Actividades.php
+++ b/main-app/class/Actividades.php
@@ -191,6 +191,26 @@ class Actividades {
     }
 
     /**
+     * Este metodo me trae las fechas de una actividad para los estudiantes
+     * @param mysqli $conexion
+     * @param array $config
+     * @param string $idActividad
+     * 
+     * @return array $resultado
+     */
+    public static function traerFechaActividadEstudiante(mysqli $conexion, array $config, string $idActividad){
+        try{
+            $consulta = mysqli_query($conexion, "SELECT TIMESTAMPDIFF(MINUTE, tar_fecha_disponible, now()), TIMESTAMPDIFF(MINUTE, tar_fecha_entrega, now()) FROM ".BD_ACADEMICA.".academico_actividad_tareas WHERE tar_id='".$idActividad."' AND tar_estado=1 AND institucion={$config['conf_id_institucion']} AND year={$_SESSION["bd"]}");
+        } catch (Exception $e) {
+            echo "Excepción catpurada: ".$e->getMessage();
+            exit();
+        }
+        $resultado = mysqli_fetch_array($consulta, MYSQLI_BOTH);
+
+        return $resultado;
+    }
+
+    /**
      * Este metodo me trae las fechas de una actividad
      * @param mysqli $conexion
      * @param array $config

--- a/main-app/estudiante/actividades-ver.php
+++ b/main-app/estudiante/actividades-ver.php
@@ -18,7 +18,7 @@ if($actividad[0]==""){
 	exit();
 }
 
-$fechas = Actividades::traerFechaActividad($conexion, $config, $idR);
+$fechas = Actividades::traerFechaActividadEstudiante($conexion, $config, $idR);
 if($fechas[0]<0){
 	echo '<script type="text/javascript">window.location.href="page-info.php?idmsg=206&fechaD='.$actividad['tar_fecha_disponible'].'&diasF='.$fechas[0].'";</script>';
 	exit();


### PR DESCRIPTION
EL método anterior estaba usando la funcion DATEDIFF que calcula en fechas mientras que para los estudiantes se usa TIMESTAMPDIFF que calcula fechas y horas, al momento de implementar el método no me fije de esa diferencia en las consultas