### PR TITLE
HF - Remover reestricción de recuperar en periodos anteriores

### DIFF
--- a/main-app/docente/indicadores-recuperar.php
+++ b/main-app/docente/indicadores-recuperar.php
@@ -5,7 +5,6 @@ include("../compartido/historial-acciones-guardar.php");
 include("verificar-carga.php");
 
 //Hay acciones que solo son permitidos en periodos diferentes al actual.
-include("verificar-periodos-iguales.php");
 include("../compartido/head.php");
 
 require_once("../class/Estudiantes.php");


### PR DESCRIPTION
El objetivo de esta pagina es precisamente poder modificar en periodos diferentes al actual. Por consiguiente se debia remover esta validación.