### PR TITLE
PES-1231 - Corregir el proceso de inscripción múltiples veces al mismo cursos, en media técnica.(MAIN)

### DIFF
--- a/main-app/class/servicios/MediaTecnicaServicios.php
+++ b/main-app/class/servicios/MediaTecnicaServicios.php
@@ -109,28 +109,28 @@ class MediaTecnicaServicios extends Servicios
                    FROM " . BD_ADMIN . ".mediatecnica_matriculas_cursos
                    
                    LEFT JOIN " . BD_ACADEMICA . ".academico_matriculas mat 
-                   ON  matcur_id_matricula = mat.mat_id 
-                   AND mat.institucion     = mat.institucion
-                   AND mat.year            = mat.year
+                   ON  mat.mat_id          = matcur_id_matricula
+                   AND mat.institucion     = matcur_id_institucion
+                   AND mat.year            = matcur_years
 
                    LEFT JOIN " . BD_ACADEMICA . ".academico_grados gra 
                    ON gra_id           = matcur_id_curso 
-                   AND gra.institucion = mat.institucion 
-                   AND gra.year        = mat.year
+                   AND gra.institucion = matcur_id_institucion 
+                   AND gra.year        = matcur_years
 
                    LEFT JOIN " . BD_ACADEMICA . ".academico_grupos gru 
                    ON gru.gru_id       = matcur_id_grupo 
-                   AND gru.institucion = mat.institucion
-                   AND gru.year        = mat.year
+                   AND gru.institucion = matcur_id_institucion
+                   AND gru.year        = matcur_years
 
                    LEFT JOIN " . BD_GENERAL . ".usuarios uss 
                    ON uss_id           = mat.mat_id_usuario 
-                   AND uss.institucion = mat.institucion
-                   AND uss.year        = mat.year
+                   AND uss.institucion = matcur_id_institucion
+                   AND uss.year        = matcur_years
 
                    LEFT JOIN ".BD_GENERAL.".usuarios  acud
-                   ON acud.institucion          = mat.institucion
-						       AND acud.year                = mat.year
+                   ON acud.institucion          = matcur_id_institucion
+						       AND acud.year                = matcur_years
 						       AND acud.uss_id              = mat.mat_acudiente
 
                    LEFT JOIN " . BD_ADMIN . ".opciones_generales 

--- a/main-app/directivo/cursos-editar.php
+++ b/main-app/directivo/cursos-editar.php
@@ -558,7 +558,7 @@ if (!Modulos::validarPermisoEdicion()) {
                                                                                 <?php
                                                                                 $cv = Grupos::traerGrupos($conexion, $config);
                                                                                 while ($rv = mysqli_fetch_array($cv, MYSQLI_BOTH)) {
-                                                                                    if ($rv[0] == $idEstudiante['matcur_id_grupo'])
+                                                                                    if ($rv['gru_id'] == $idEstudiante['matcur_id_grupo'])
                                                                                         echo '<option value="' . $rv['gru_id'] . '" selected>' . $rv['gru_nombre'] . '</option>';
                                                                                     else
                                                                                         echo '<option value="' . $rv['gru_id'] . '">' . $rv['gru_nombre'] . '</option>';

--- a/main-app/directivo/fetch-estudiante-mediatecnica.php
+++ b/main-app/directivo/fetch-estudiante-mediatecnica.php
@@ -24,22 +24,28 @@ if (!empty($tipo)) {
     try {
         switch ($tipo) {
             case ACCION_CREAR:
-                $parametros = [
-                    'matcur_id_curso' => $curso,
-                    'matcur_id_institucion' => $config['conf_id_institucion'],
-                    'matcur_years' => $config['conf_agno']
-                ];
-                $cantidad = MediaTecnicaServicios::contar($parametros);
-                // se valida que tenga disponibilidad el curso
-                if (intval($cantidad) >= intval($cursoActual["gra_maximum_quota"])) {
+                $existeEstudianteMT = MediaTecnicaServicios::existeEstudianteMTCursos($matricula, $curso, $config, $config['conf_agno']);
+                if (!$existeEstudianteMT) {
+                    $parametros = [
+                        'matcur_id_curso' => $curso,
+                        'matcur_id_institucion' => $config['conf_id_institucion'],
+                        'matcur_years' => $config['conf_agno']
+                    ];
+                    $cantidad = MediaTecnicaServicios::contar($parametros);
+                    // se valida que tenga disponibilidad el curso
+                    if (intval($cantidad) >= intval($cursoActual["gra_maximum_quota"])) {
+                        $response["ok"] = false;
+                        $response["msg"] = "El cupo maximo del curso " . $cursoActual["gra_nombre"] . " es de " . $cursoActual["gra_maximum_quota"];
+                        echo json_encode($response);
+                        exit();
+                    }
+                    MediaTecnicaServicios::guardarPorCurso($matricula, $curso);
+                    $response["ok"] = true;
+                    $response["msg"] = "Se Agregó a ".MatriculaServicios::nombreCompleto($matricualActual)." en el cruso ". $cursoActual["gra_nombre"] . " correctamente.";
+                } else {
                     $response["ok"] = false;
-                    $response["msg"] = "El cupo maximo del curso " . $cursoActual["gra_nombre"] . " es de " . $cursoActual["gra_maximum_quota"];
-                    echo json_encode($response);
-                    exit();
+                    $response["msg"] = "El estudiante ".MatriculaServicios::nombreCompleto($matricualActual)." ya existe en el cruso ". $cursoActual["gra_nombre"] . ".";
                 }
-                MediaTecnicaServicios::guardarPorCurso($matricula, $curso);
-                $response["ok"] = true;
-                $response["msg"] = "Se Agregó a ".MatriculaServicios::nombreCompleto($matricualActual)." en el cruso ". $cursoActual["gra_nombre"] . " correctamente.";
                 break;
             case ACCION_MODIFICAR:
                 if (empty($input)) {


### PR DESCRIPTION
Verificando la consulta se encuentra que los estudiantes repetidos no era por que lo estuvieran en la BD, era por la estructura de la consulta que se mostraban repetidos, se corrige la consulta y ya no los muestra repetidos, aparte también añadimos un validación al crear el estudiantes en MT para no repetir un estúdiate para un mismo curso de MT.

![image](https://github.com/user-attachments/assets/ca2702dc-0a3a-4c63-8676-7f8b90686e10)
