### PR TITLE
HTF - Para permitir parámetros de SION se añaden caracteres como @'_,

### DIFF
--- a/main-app/class/Utilidades.php
+++ b/main-app/class/Utilidades.php
@@ -128,7 +128,7 @@ class Utilidades {
      * $esValido = esAlfanumerico('nombre123');
      *  */
     public static function esAlfanumerico($valor) {
-        return preg_match('/^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ,-:.!\s]+$/', $valor);
+        return preg_match('/^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ,-_:.!\'@()\s]+$/', $valor);
     }
 
     /**


### PR DESCRIPTION
Para permitir parámetros de SION se añaden caracteres como @'_, ya que por esos caracteres al retornar a la pagina de estudiantes.php, se recibía este mensaje "El procedimiento o la función 'INSERTAR_TERCERO_SINTIA' esperaba el parámetro '@NombreOtrosAcudiente', que no se ha especificado." y en la validación lo enviaba a page-info.php con el mensaje 307, esto al transferir un estudiante a SION

![image](https://github.com/user-attachments/assets/ed19653a-ccf1-44b5-86e4-305658e2f1b3)
