### PR TITLE
HTF - Corrección de error encontrado al exportar estudiantes

### DIFF
--- a/main-app/class/UsuariosPadre.php
+++ b/main-app/class/UsuariosPadre.php
@@ -258,6 +258,7 @@ class UsuariosPadre {
 
         $sql = "SELECT * FROM ".BD_GENERAL.".usuarios uss 
         INNER JOIN ".BD_ADMIN.".general_perfiles ON pes_id=uss_tipo 
+        LEFT JOIN ".BD_ADMIN.".opciones_generales ON ogen_id = uss.uss_tipo_documento
         WHERE uss.institucion=? AND uss.year=? {$filtroBusqueda}";
         $parametros = [$idInsti, $year];
         $consultaUsuario = BindSQL::prepararSQL($sql, $parametros);

--- a/main-app/compartido/excel-estudiantes.php
+++ b/main-app/compartido/excel-estudiantes.php
@@ -101,7 +101,7 @@ while($resultado=mysqli_fetch_array($consulta, MYSQLI_BOTH))
             <td align="center"><?=$resultado['mat_numero_matricula'];?></td>
 
             <td><?=$datosA['ogen_nombre'];?></td>
-            <td><?=$datosA['uss_usuario'];?></td>
+            <td><?=$datosA['uss_documento'];?></td>
             <td align="center"><?php
                 if(!empty($datosA['uss_apellido1'])){ 
                     $nombreCompleto = !empty($datosA['uss_apellido1']) ? 


### PR DESCRIPTION
Nos reportan que al momento de exportar a los estudiantes, en la parte del documento no se muestra bien el documento del padre de familia, se ve que es por que en este archivo de exportacion aun se esta usando el campo de uss_usuario en donde se deberia ver el documento del acudiente, se cambia de uss_usuario a uss_documento y se corrige esto, adicional se ve que no se esta mostrando el tipo de documento, se agrega un left join a la consulta para traer este valor y se muestra en el archivo