### PR TITLE
HTF - Se corrige error por ligaduras tipográficas

### DIFF
--- a/config-general/idiomas.php
+++ b/config-general/idiomas.php
@@ -648,7 +648,7 @@ $frases[314][$l] = 'Pagos';
 
 $frases[315][$l] = 'Saldo';
 
-$frases[316][$l] = 'Recuerde que su código para hacer el pago es el siguiente';
+$frases[316][$l] = 'Recuerde que su código para hacer el pago es';
 
 $frases[317][$l] = 'Link de pago';
 
@@ -1463,7 +1463,7 @@ $frases[314][$l] = 'Payments';
 
 $frases[315][$l] = 'Balance';
 
-$frases[316][$l] = 'Remember that your payment code is as follows';
+$frases[316][$l] = 'Remember that your payment code is';
 
 $frases[317][$l] = 'Payment link';
 

--- a/main-app/compartido/estado-de-cuenta-contenido.php
+++ b/main-app/compartido/estado-de-cuenta-contenido.php
@@ -36,9 +36,9 @@
 
 									<?php if($config['conf_id_institucion'] == ICOLVEN) {?>
 										<div align="center">
-											<p><mark><?=$frases[316][$datosUsuarioActual['uss_idioma']];?>: <b><?php if(!empty($datosEstudianteActual['mat_codigo_tesoreria'])){ echo $datosEstudianteActual['mat_codigo_tesoreria'];}?></b></mark></p>
+											<p><mark><?=$frases[316][$datosUsuarioActual['uss_idioma']];?>: <b><?php if(!empty($datosEstudianteActual['mat_codigo_tesoreria'])){ echo $datosEstudianteActual['mat_codigo_tesoreria'];}?></b>  (cuatro dígitos, sin el 0 a la izquierda).</mark></p>
 
-											<p><a href="https://www.pagosvirtualesavvillas.com.co/personal/pagos/22" class="btn btn-info" target="_blank"><?=strtoupper($frases[317][$datosUsuarioActual['uss_idioma']]);?></a></p>
+											<p><a href="https://www.avalpaycenter.com/wps/portal/portal-de-pagos/web/pagos-aval/resultado-busqueda/realizar-pago-facturadores?idConv=00022724&origen=buscar" class="btn btn-info" target="_blank"><?=strtoupper($frases[317][$datosUsuarioActual['uss_idioma']]);?></a></p>
 
 											<p><a href="http://sion.icolven.edu.co/Services/ServiceIcolven.svc/GenerarEstadoCuenta/<?=$datosEstudianteActual['mat_codigo_tesoreria'];?>/<?=date('Y');?>" class="btn btn-success" target="_blank"><?=strtoupper($frases[104][$datosUsuarioActual['uss_idioma']]);?></a></p>
 										</div>

--- a/main-app/docente/calificaciones-actualizar.php
+++ b/main-app/docente/calificaciones-actualizar.php
@@ -22,6 +22,7 @@ $porcentajeRestante = $indicadoresDatosC['ipc_valor'] - $valores[0];
 $porcentajeRestante = ($porcentajeRestante + $valorCalificacion);
 
 $fecha = date('Y-m-d', strtotime(str_replace('-', '/', $_POST["fecha"])));
+$_POST["contenido"] = str_replace(['ﬁ', 'ﬂ', 'ﬀ', 'ﬃ', 'ﬄ', 'ﬆ'], ['fi', 'fl', 'ff', 'ffi', 'ffl', 'st'], $_POST["contenido"]);
 
 //Si las calificaciones son de forma automática.
 if($datosCargaActual['car_configuracion']==0){

--- a/main-app/docente/calificaciones-guardar.php
+++ b/main-app/docente/calificaciones-guardar.php
@@ -28,6 +28,7 @@ if($valores[1]>=$datosCargaActual['car_maximas_calificaciones']){
 $infoCompartir=0;
 if(!empty($_POST["compartir"]) && $_POST["compartir"]==1) $infoCompartir=1;
 $fecha = date('Y-m-d', strtotime(str_replace('-', '/', $_POST["fecha"])));
+$_POST["contenido"] = str_replace(['ﬁ', 'ﬂ', 'ﬀ', 'ﬃ', 'ﬄ', 'ﬆ'], ['fi', 'fl', 'ff', 'ffi', 'ffl', 'st'], $_POST["contenido"]);
 
 if(empty($_POST["bancoDatos"]) || $_POST["bancoDatos"]==0){
 	//Si los valores de las calificaciones son de forma automática.

--- a/main-app/docente/indicadores-actualizar.php
+++ b/main-app/docente/indicadores-actualizar.php
@@ -14,6 +14,7 @@ $sumaIndicadores = Indicadores::consultarSumaIndicadores($conexion, $config, $ca
 $porcentajePermitido = 100 - $sumaIndicadores[0];
 $porcentajeRestante = ($porcentajePermitido - $sumaIndicadores[1]);
 $porcentajeRestante = ($porcentajeRestante + $_POST["valorIndicador"]);
+$_POST["contenido"] = str_replace(['ﬁ', 'ﬂ', 'ﬀ', 'ﬃ', 'ﬄ', 'ﬆ'], ['fi', 'fl', 'ff', 'ffi', 'ffl', 'st'], $_POST["contenido"]);
 
 $update = [
 	'ind_nombre' => mysqli_real_escape_string($conexion,$_POST["contenido"])

--- a/main-app/docente/indicadores-guardar.php
+++ b/main-app/docente/indicadores-guardar.php
@@ -20,6 +20,7 @@ if($sumaIndicadores[2]>=$datosCargaActual['car_maximos_indicadores']){
 	echo '<script type="text/javascript">window.location.href="page-info.php?idmsg=209";</script>';
 	exit();
 }
+$_POST["contenido"] = str_replace(['ﬁ', 'ﬂ', 'ﬀ', 'ﬃ', 'ﬄ', 'ﬆ'], ['fi', 'fl', 'ff', 'ffi', 'ffl', 'st'], $_POST["contenido"]);
 
 $infoCompartir=0;
 if(!empty($_POST["compartir"]) && $_POST["compartir"]==1) $infoCompartir=1;


### PR DESCRIPTION
Se detecta un error al momento de guardar un indicador, contactamos con la docente afectada y solicitamos información del indicador, haciendo prueba nos damos cuenta de que es un error por ligaduras tipográficas el texto era "Conocer: Comprende cómo la filosofía es una actividad que se aprende aplicando herramientas de reflexión y ejercitando el razonamiento lógico."

El texto contiene dos caracteres problemáticos que pueden causar problemas en una consulta PDO si la codificación no es correcta:

ﬁ (ligadura de "fi")

Este carácter (ﬁ) es una ligadura tipográfica y no la secuencia de caracteres estándar "f" + "i".
Puede aparecer en documentos con tipografías avanzadas o si el texto se ha copiado de un PDF o Word.
Su código Unicode es U+FB01.
ﬂ (ligadura de "fl")

Similar al anterior, ﬂ es otra ligadura tipográfica.
Código Unicode: U+FB02. 

Se sustituye todas las ligaduras mas comunes por sus versiones estándar.

--------------------------------------------------------------------------------------
Se modifica texto y enlace de pago en estado de cuenta de los estudiantes