### PR TITLE
HTF - Se corrige detalle para enviar documento a SION y se valida que exista el correo del usuario

### DIFF
--- a/main-app/directivo/estudiantes-crear-sion.php
+++ b/main-app/directivo/estudiantes-crear-sion.php
@@ -33,7 +33,7 @@
         "SexoEstudiante" => $datosEstudianteActual["mat_genero"],
 
         "IdTipoDocumentoAcudiente" => $acudiente["uss_tipo_documento"],
-        "DocumentoAcudiente" => $acudiente["uss_usuario"],
+        "DocumentoAcudiente" => $acudiente["uss_documento"],
         "Apellido1Acudiente" => $acudiente["uss_apellido1"],
         "Apellido2Acudiente" => $acudiente["uss_apellido2"],
         "Nombre1Acudiente" => $acudiente["uss_nombre"],

--- a/main-app/recuperar-clave-enviar-codigo.php
+++ b/main-app/recuperar-clave-enviar-codigo.php
@@ -20,7 +20,8 @@ if (!empty($_REQUEST['Usuario'])) {
 
 if ($usuariosEncontrados == 1) {
 	$datosUsuario = !empty($_REQUEST['Usuario']) ? $datosUsuario[0] : $datosUsuario;
-	if (!empty($datosUsuario)) {
+	if (!empty($datosUsuario) && !empty($datosUsuario['uss_email'])) {
+
         $data = [
             'usuario_nombre'      => $datosUsuario['uss_nombre'] . ' ' . $datosUsuario['uss_apellido1'],
             'institucion_id'      => $datosUsuario['institucion'],


### PR DESCRIPTION
HTF - Se corrige detalle para enviar documento a SION y no usuario, y tambien se valida que exista el correo del usuario antes de enviar codigo al recuperar clave

Antes de hacer el primer commit se valido que todo los usuarios en ICOLVEN para el año actual tuvieran el campo uss_documento lleno, solo se hizo en icolven por lo que son los unicos que usan SION.

Para el segundo commit se cambiaron los correos inventados a NULL