### PR TITLE
HTF - Se cambia a inform antiguo temporalmente mientras se revisa el informe fast

### DIFF
--- a/main-app/directivo/informe-parcial-grupo-modal.php
+++ b/main-app/directivo/informe-parcial-grupo-modal.php
@@ -17,7 +17,7 @@ if (!Modulos::validarSubRol([$idPaginaInterna])) {
     <div class="panel-body">
 
 
-        <form action="../compartido/informe-parcial-grupo-detalle-fast.php" method="post" class="form-horizontal" enctype="multipart/form-data" target="_blank">
+        <form action="../compartido/informe-parcial-grupo-detalle.php" method="post" class="form-horizontal" enctype="multipart/form-data" target="_blank">
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">Curso</label>


### PR DESCRIPTION
La docente Herlinda del tagui esta tratando de imprimir el informe parcial por grupo y no le permite, hice la prueba con otra institución y tampoco funciona, no pude entender muy bien la consulta de ese informe fast por ende opte a usar el antiguo mientras se corrige este error ya que la institucion lo quiere urgente