### PR TITLE
HF - Obtener el último usuario registrado cuando haya varios

### DIFF
--- a/main-app/class/Autenticate.php
+++ b/main-app/class/Autenticate.php
@@ -66,7 +66,7 @@ class Autenticate {
         AND TRIM(uss_usuario)!='' 
         AND uss_clave=SHA1('".$pass."')  
         AND uss_usuario IS NOT NULL  
-        ORDER BY uss_ultimo_ingreso DESC 
+        ORDER BY id_nuevo DESC 
         LIMIT 1";
 
         $conexion = Conexion::newConnection('MYSQL');


### PR DESCRIPTION
Al estar un usuario en dos instituciones en el mismo año se presentaba el problema de que estaba obteniendo el usuario no deseado.
Esto es algo para revisar con más detalles porque deben impedirte que otra institución cree un usuario si esté aún está activo en otra Institución