### PR TITLE
HTF - Se corrigen errores detectados por usuarios

### DIFF
--- a/main-app/estudiante/cargas.php
+++ b/main-app/estudiante/cargas.php
@@ -121,7 +121,7 @@ if($config['conf_activar_encuesta']==1){
 		                            <div class="text-muted">
 										<span class="m-r-10" style="font-size: 10px;"><?=$ultimoAcceso;?></span> 
 										
-		                            	<?php if($datosUsuarioActual['uss_bloqueado']!=1 and $config['conf_sin_nota_numerica']!=1){?><a class="course-likes m-l-10" href="#"> <?=$definitivaFinal;?></a><?php }?>
+		                            	<?php if($datosUsuarioActual['uss_bloqueado'] != 1 && $config['conf_sin_nota_numerica'] != 1 && $config['conf_mostrar_calificaciones_estudiantes'] == 1){?><a class="course-likes m-l-10" href="#"> <?=$definitivaFinal;?></a><?php }?>
 										
 		                            </div>
 		                            <p><span><i class="fa fa-clock-o"></i> <?=$frases[101][$datosUsuarioActual['uss_idioma']];?>: <?=$rCargas['car_periodo'];?></span></p>
@@ -183,7 +183,7 @@ if($config['conf_activar_encuesta']==1){
 											<div class="text-muted">
 												<span class="m-r-10" style="font-size: 10px;"><?= $ultimoAcceso; ?></span>
 
-												<?php if ($datosUsuarioActual['uss_bloqueado'] != 1 and $config['conf_sin_nota_numerica'] != 1) { ?><a class="course-likes m-l-10" href="#"> <?= $definitiva; ?></a><?php } ?>
+												<?php if ($datosUsuarioActual['uss_bloqueado'] != 1 && $config['conf_sin_nota_numerica'] != 1 && $config['conf_mostrar_calificaciones_estudiantes'] == 1) { ?><a class="course-likes m-l-10" href="#"> <?= $definitiva; ?></a><?php } ?>
 
 											</div>
 											<p><span><i class="fa fa-clock-o"></i> <?= $frases[101][$datosUsuarioActual['uss_idioma']]; ?>: <?= $cargaMediaTecnica['car_periodo']; ?></span></p>

--- a/main-app/recuperar-clave-guardar.php
+++ b/main-app/recuperar-clave-guardar.php
@@ -8,39 +8,26 @@ require_once(ROOT_PATH . "/main-app/class/EnviarEmail.php");
 $conexion = mysqli_connect($servidorConexion, $usuarioConexion, $claveConexion, $baseDatosServicios);
 
 $year_actual=date('Y');
+$datosUsuario = Usuarios::buscarUsuarioIdNuevo($_POST['usuarioId']);
 
-if (!empty($_POST['Usuario'])) {
-    $datosUsuario = Usuarios::buscarUsuariosRecuperarClave($_POST['Usuario'],$year_actual);
-} elseif (!empty($_POST['usuarioId'])) {
-    $datosUsuario = Usuarios::buscarUsuarioIdNuevo($_POST['usuarioId']);
-}
+if (!empty($datosUsuario)) {
+	$data = [
+		'institucion_id'   => $datosUsuario['institucion'],
+		'institucion_agno' => $year_actual,
+		'usuario_id'       => $datosUsuario['uss_id'],
+		'usuario_email'    => $datosUsuario['uss_email'],
+		'usuario_nombre'   => $datosUsuario['uss_nombre'],
+		'usuario_usuario'  => $datosUsuario['uss_usuario'],
+		'nueva_clave'      => $_REQUEST['password'],
+	];
+	$asunto = 'Tus credenciales han llegado';
+	$bodyTemplateRoute = ROOT_PATH . '/config-general/template-email-recuperar-clave.php';
 
-$usuariosEncontrados = count($datosUsuario);
+	EnviarEmail::enviar($data, $asunto, $bodyTemplateRoute, null, null);
+	Usuarios::guardarRegistroRestauracion($data);
 
-if ($usuariosEncontrados == 1) {
-	$datosUsuario = $datosUsuario[0];
-	if (!empty($datosUsuario)) {
-		$data = [
-			'institucion_id'   => $datosUsuario['institucion'],
-			'institucion_agno' => $year_actual,
-			'usuario_id'       => $datosUsuario['uss_id'],
-			'usuario_email'    => $datosUsuario['uss_email'],
-			'usuario_nombre'   => $datosUsuario['uss_nombre'],
-			'usuario_usuario'  => $datosUsuario['uss_usuario'],
-			'nueva_clave'      => $_REQUEST['password'],
-		];
-		$asunto = 'Tus credenciales han llegado';
-		$bodyTemplateRoute = ROOT_PATH . '/config-general/template-email-recuperar-clave.php';
-
-		EnviarEmail::enviar($data, $asunto, $bodyTemplateRoute, null, null);
-		Usuarios::guardarRegistroRestauracion($data);
-
-		echo '<script type="text/javascript">window.location.href="index.php?success=SC_DT_5&email=' . base64_encode($datosUsuario['uss_email']) . '";</script>';
-		exit();
-	} else {
-		echo '<script type="text/javascript">window.location.href="recuperar-clave-restaurar.php?usuarioId='.base64_encode($_REQUEST['usuarioId']).'&error=1";</script>';
-		exit();
-	}
+	echo '<script type="text/javascript">window.location.href="index.php?success=SC_DT_5&email=' . base64_encode($datosUsuario['uss_email']) . '";</script>';
+	exit();
 } else {
 	echo '<script type="text/javascript">window.location.href="recuperar-clave-restaurar.php?usuarioId='.base64_encode($_REQUEST['usuarioId']).'&error=1";</script>';
 	exit();


### PR DESCRIPTION
En el primer commit se quita la validación y lo relacionado con $_POST['Usuario'] porque ese campo nunca llega a ese archivo, y de esa forma se corrige un error que habia al momento de reestablecer la contraseña detectado gracias a un reporte de una acudiente.

En el segundo commit se valida el mostrar a los estudiantes la nota definitiva que se lleva en la pagina de cargas, se valida con el campo que se puede configurar desde la configuración del sistema