### PR TITLE
HTF - Se añade get búsqueda para  los archivos que aun usan el buscador de la barra.

### DIFF
--- a/main-app/class/Utilidades.php
+++ b/main-app/class/Utilidades.php
@@ -65,7 +65,7 @@ class Utilidades {
 
             foreach ($get as $key => $value) {
                 // validammos que los parametros no sean null y sea base64  excluyendo cuando la llave sea success , error,summary  y validamos que el resultado es codificado es  alfanumerico   
-                if ($key != 'success' && $key != 'error' &&  $key != 'summary' && !empty($value) && (!self::esBase64($value) || !self::esAlfanumerico(base64_decode($value)))) {
+                if ($key != 'success' && $key != 'error' &&  $key != 'summary' &&  $key != 'busqueda' && !empty($value) && (!self::esBase64($value) || !self::esAlfanumerico(base64_decode($value)))) {
                     echo '<script type="text/javascript">window.location.href="page-info.php?idmsg=307";</script>';
                     exit();
                 }


### PR DESCRIPTION
Hay archivos como en el listado de reportes disciplinarios donde no permite realizar la búsqueda por que la función Utilidades::validarParametros($_GET); no lo permite debido a que lo que que ingresa el usuario en el campo de búsqueda no se puede pasar a base64, entonces al realizar la búsqueda y darle al botón buscar, se recarga la pagina y al llevar ese get no pasa el método